### PR TITLE
Update the min and max dates for the calender picker

### DIFF
--- a/bookingcalendar.js
+++ b/bookingcalendar.js
@@ -25,86 +25,78 @@ window.onload = async () => {
     });
   }
 
+  async function setupDatePickers() {
+    try {
+      const checkIn = await Wized.data.get("r.4.d.availability.start_date");
+      const checkOut = await Wized.data.get("r.4.d.availability.end_date");
+      const arrival = await Wized.data.get("r.4.d.arrival_date");
+      const departure = await Wized.data.get("r.4.d.departure_date");
+
+      const startDate = new Date(checkIn);
+      const endDate = new Date(checkOut);
+      const arrivalDate = new Date(arrival);
+      const departureDate = new Date(departure);
+
+      // Create min and max dates for custom check-in and check-out
+      const minCustomCheckInDate = new Date(startDate);
+      minCustomCheckInDate.setDate(minCustomCheckInDate.getDate() + 2);
+      const maxCustomCheckOutDate = new Date(endDate);
+      maxCustomCheckOutDate.setDate(maxCustomCheckOutDate.getDate());
+
+      // Update the initializeDatePicker function calls
+      initializeDatePicker(
+        "arrival-picker",
+        arrivalDate,
+        minCustomCheckInDate,
+        endDate,
+        "newArrival"
+      );
+      initializeDatePicker(
+        "departure-picker",
+        departureDate,
+        startDate,
+        maxCustomCheckOutDate,
+        "newDeparture"
+      );
+    } catch (error) {
+      console.error("Error initializing date pickers:", error);
+    }
+  }
+
   if (typeof Wized !== "undefined") {
-    Wized.request.awaitAllPageLoad(async () => {
-      try {
-        const checkIn = await Wized.data.get("r.4.d.availability.start_date");
-        const checkOut = await Wized.data.get("r.4.d.availability.end_date");
-        const arrival = await Wized.data.get("r.4.d.arrival_date");
-        const departure = await Wized.data.get("r.4.d.departure_date");
-
-        const startDate = new Date(checkIn);
-        const endDate = new Date(checkOut);
-        const arrivalDate = new Date(arrival);
-        const departureDate = new Date(departure);
-
-        initializeDatePicker(
-          "arrival-picker",
-          arrivalDate,
-          startDate,
-          endDate,
-          "newArrival"
-        );
-        initializeDatePicker(
-          "departure-picker",
-          departureDate,
-          startDate,
-          endDate,
-          "newDeparture"
-        );
-      } catch (error) {
-        console.error("Error initializing date pickers:", error);
-      }
-    });
+    Wized.request.awaitAllPageLoad(setupDatePickers);
   } else {
-    console.error('Wized is not defined.');
+    console.error("Wized is not defined.");
+  }
+  
+  function initializeDatePicker(elementId, defaultDate, minDate, maxDate, dataVariable) {
+    const picker = new easepick.create({
+      element: document.getElementById(elementId),
+      css: ["https://csb-hrpwdp.netlify.app/augustcalendar.css"],
+      plugins: ["LockPlugin"],
+      format: "DD MMM YYYY",
+      LockPlugin: {
+        minDate: minDate,
+        maxDate: maxDate // Ensure maxDate is included
+      },
+      setup(picker) {
+        picker.on("select", async (e) => {
+          const { date } = e.detail;
+          const selectedDate = date.format("YYYY-MM-DD");
+          
+          // Use setTimeout to ensure UI refresh
+          setTimeout(async () => {
+            try {
+              await Wized.data.setVariable(dataVariable, selectedDate);
+            } catch (error) {
+              console.error(`Error updating Wized variable: ${dataVariable}`, error);
+            }
+          }, 0); // Wait for the current execution queue to clear
+        });
+      },
+    });
+
+    picker.gotoDate(defaultDate);
+    picker.setDate(defaultDate);
   }
 };
-
-function initializeDatePicker(elementId, defaultDate, minDate, maxDate, dataVariable) {
-  const picker = new easepick.create({
-    element: document.getElementById(elementId),
-    css: ["https://csb-hrpwdp.netlify.app/augustcalendar.css"],
-    plugins: ["LockPlugin"],
-    format: "DD MMM YYYY",
-    LockPlugin: {
-      minDate: minDate,
-      maxDate: maxDate // Ensure maxDate is included
-    },
-    setup(picker) {
-      picker.on("select", async (e) => {
-        const { date } = e.detail;
-        const selectedDate = date.format("YYYY-MM-DD");
-        
-        // Use setTimeout to ensure UI refresh
-        setTimeout(async () => {
-          try {
-            await Wized.data.setVariable(dataVariable, selectedDate);
-          } catch (error) {
-            console.error(`Error updating Wized variable: ${dataVariable}`, error);
-          }
-        }, 0); // Wait for the current execution queue to clear
-      });
-    },
-  });
-
-  picker.gotoDate(defaultDate);
-  picker.setDate(defaultDate);
-}
-
-// Calls to initializeDatePicker
-initializeDatePicker(
-  "arrival-picker",
-  arrivalDate,
-  startDate,
-  endDate,
-  "newArrival"
-);
-
-initializeDatePicker(
-  "departure-picker",
-  departureDate,
-  startDate,
-  endDate,
-  "newDeparture"
-);


### PR DESCRIPTION
Customers were previously able to select an arrival date that was before the start of the rental. And the same for departing. This fix provides a solution to that by blocking off the arrival and departure dates and only allowing dates after the start date or before the end date to be updates by the customer.